### PR TITLE
[RT-74] Add Scala 2.12 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,8 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.qubole.spark</groupId>
-  <artifactId>spark-sql-kinesis_2.11</artifactId>
-  <version>1.2.1_spark-2.4-SNAPSHOT</version>
+  <artifactId>spark-sql-kinesis_2.12</artifactId>
+  <version>1.2.1_spark-2.4-aiq1</version>
   <packaging>jar</packaging>
   <name>Kinesis Integration for Structured Streaming</name>
   <description>Connector to read from and write into Kinesis from Structured Streaming Applications</description>
@@ -50,7 +50,7 @@
     <connection>scm:git:git://github.com/qubole/kinesis-sql.git</connection>
     <url>http://github.com/qubole/kinesis-sql</url>
     <developerConnection>scm:git:git@github.com:qubole/kinesis-sql.git</developerConnection>
-    <tag>spark-sql-kinesis_2.11-1.2.0-spark_2.4</tag>
+    <tag>spark-sql-kinesis_2.12-1.2.0-spark_2.4</tag>
   </scm>
 
   <inceptionYear>2018</inceptionYear>
@@ -62,7 +62,7 @@
   <properties>
     <sbt.project.name>sql-kinesis</sbt.project.name>
     <spark.version>2.4.0</spark.version>
-    <scala.binary.version>2.11</scala.binary.version>
+    <scala.binary.version>2.12</scala.binary.version>
     <fasterxml.jackson.version>2.6.7</fasterxml.jackson.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -145,7 +145,7 @@
     </dependency>
     <dependency>
       <groupId>org.scalatest</groupId>
-      <artifactId>scalatest_2.11</artifactId>
+      <artifactId>scalatest_2.12</artifactId>
       <version>3.0.3</version>
       <scope>test</scope>
     </dependency>
@@ -169,8 +169,29 @@
   </dependencies>
 
   <build>
+    <extensions>
+      <extension>
+        <groupId>com.github.seahen</groupId>
+        <artifactId>maven-s3-wagon</artifactId>
+        <version>1.3.3</version>
+      </extension>
+    </extensions>
+
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>3.2.0</version>
+          <executions>
+            <execution>
+              <id>attach-sources</id>
+              <goals>
+                <goal>jar</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
         <plugin>
           <groupId>org.scalatest</groupId>
           <artifactId>scalatest-maven-plugin</artifactId>
@@ -406,14 +427,14 @@
   </profiles>
 
   <distributionManagement>
-    <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
     <repository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+      <id>aws-releases</id>
+      <url>s3://aiq-artifacts/releases</url>
     </repository>
+    <snapshotRepository>
+      <id>aws-snapshots</id>
+      <url>s3://aiq-artifacts/snapshots</url>
+    </snapshotRepository>
   </distributionManagement>
 
   <reporting>


### PR DESCRIPTION
Add scala 2.12 support and deploy to our S3

### Test Notes
`mvn install`

### Deploy Notes
`mvn deploy -DskipTests`, verify jars in S3
```[INFO] Uploading: s3://aiq-artifacts/releases/com/qubole/spark/spark-sql-kinesis_2.12/1.2.1_spark-2.4-aiq1/spark-sql-kinesis_2.12-1.2.1_spark-2.4-aiq1-javadoc.jar```